### PR TITLE
feat(phase1): pre-recon agent with artifact store and guided autonomy [INT-284, INT-285, INT-286, INT-287]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,8 @@ RUN LATEST=$(curl -fsSL -o /dev/null -w '%{url_effective}' \
       "https://github.com/projectdiscovery/httpx/releases/download/v${LATEST}/httpx_${LATEST}_${TARGETOS}_${TARGETARCH}.zip" \
       -o /tmp/httpx.zip \
     && unzip -q /tmp/httpx.zip httpx -d /tmp/httpx \
-    && mv /tmp/httpx/httpx /usr/local/bin/httpx \
-    && chmod +x /usr/local/bin/httpx \
+    && mv /tmp/httpx/httpx /usr/local/bin/pd-httpx \
+    && chmod +x /usr/local/bin/pd-httpx \
     && rm -rf /tmp/httpx*
 
 # ─── Stage 2: Adversa worker ──────────────────────────────────────────────────
@@ -59,6 +59,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         default-jre-headless \
         chromium \
+        libcap2-bin \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Trivy (Aqua Security SCA scanner) ─────────────────────────────────────────
@@ -66,19 +67,29 @@ RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/
       | sh -s -- -b /usr/local/bin
 
 # ── Joern (CPG / taint-flow analysis) ─────────────────────────────────────────
+# Download and extract in one step, then clean up the ~300MB zip to keep layer small
+# and avoid Docker overlay I/O errors on constrained storage.
 RUN curl -fL https://github.com/joernio/joern/releases/latest/download/joern-install.sh \
       | sh -s -- --install-dir=/opt/joern --without-plugins \
-    && ln -s /opt/joern/joern-cli/joern /usr/local/bin/joern
+    && ln -s /opt/joern/joern-cli/joern /usr/local/bin/joern \
+    && ln -s /opt/joern/joern-cli/joern-parse /usr/local/bin/joern-parse \
+    && rm -f /opt/joern/*.zip /tmp/joern* /root/joern*
 
 # ── ProjectDiscovery tools from build stage ───────────────────────────────────
 COPY --from=pd-tools /usr/local/bin/subfinder /usr/local/bin/subfinder
-COPY --from=pd-tools /usr/local/bin/httpx     /usr/local/bin/httpx
+COPY --from=pd-tools /usr/local/bin/pd-httpx   /usr/local/bin/pd-httpx
 
 # ── Python dependencies ────────────────────────────────────────────────────────
 RUN pip install --no-cache-dir uv
 
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev
+
+# ── Node.js (lockfile generation for JS/TS targets) ──────────────────────────
+# Only npm is needed — no need for full Node dev toolchain.
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
 
 # ── Semgrep (installed as Python package, exposes CLI) ─────────────────────────
 RUN uv run pip install --no-cache-dir semgrep
@@ -88,5 +99,15 @@ COPY src/ ./src/
 
 # Playwright browser path (configured in docker-compose.yml via env var)
 ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
+
+# ── Non-root user ─────────────────────────────────────────────────────────────
+# claude-agent-sdk refuses bypassPermissions under root for security reasons.
+# Running as non-root is also a container security best practice.
+RUN groupadd --gid 1000 adversa \
+    && useradd --uid 1000 --gid adversa --create-home adversa \
+    && chown -R adversa:adversa /app \
+    && setcap cap_net_raw,cap_net_admin+eip /usr/bin/nmap
+
+USER adversa
 
 CMD ["uv", "run", "python", "-m", "src.temporal.worker"]

--- a/configs/juiceshop.config.yaml
+++ b/configs/juiceshop.config.yaml
@@ -39,7 +39,7 @@ pipeline:
 
 repo:
   path: "./repos/juice-shop"
-  joern_enabled: false
+  joern_enabled: true
 
 tracing:
   enabled: true  # set false to skip Langfuse tracing

--- a/src/agents/pre_recon.py
+++ b/src/agents/pre_recon.py
@@ -1,0 +1,448 @@
+"""
+Phase 1: Pre-recon agent — runs SAST, SCA, infra scanning via claude-agent-sdk.
+
+A single LLM agent with Bash access that runs semgrep, trivy, nmap, subfinder,
+httpx, and optionally joern-parse. It writes each scan result directly to the
+artifact store via Bash, then returns a lightweight summary.
+
+Produces: SEMGREP_RAW, SBOM, INFRA_MAP, TECH_STACK, JOERN_CPG_PATH artifacts.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from claude_agent_sdk import ClaudeAgentOptions
+from pydantic import BaseModel, Field
+
+from src.artifacts.store import ArtifactStore
+from src.config.models import AdversaConfig
+from src.services.agent_runner import build_agent_env, run_agent
+
+logger = logging.getLogger(__name__)
+
+# The agent needs Bash to run scanner tools and write artifacts, Read/Glob to inspect files
+_ALLOWED_TOOLS = ["Bash", "Read", "Glob", "Grep"]
+
+
+# ─── Simplified structured output schema ─────────────────────────────────────
+# The agent writes full scan data to artifact files via Bash.
+# Structured output is just a summary for the activity to check status.
+
+
+class PreReconSummary(BaseModel):
+    """Lightweight summary returned by the pre-recon agent."""
+    semgrep_findings_count: int = Field(description="Total Semgrep findings")
+    semgrep_error: str | None = Field(default=None, description="Error if Semgrep failed")
+    sca_vulns_count: int = Field(description="Total Trivy CVE vulnerabilities")
+    sca_lockfile_found: bool = Field(description="Whether a lockfile was found or generated")
+    sca_error: str | None = Field(default=None, description="Error if Trivy failed")
+    infra_open_ports: int = Field(description="Total open ports found by nmap")
+    joern_success: bool = Field(description="Whether Joern CPG was built")
+    joern_error: str | None = Field(default=None, description="Error if Joern failed or was skipped")
+    summary: str = Field(description="One-paragraph summary of all scan results")
+
+
+_OUTPUT_FORMAT: dict = {
+    "type": "json_schema",
+    "schema": PreReconSummary.model_json_schema(),
+}
+
+
+# ─── Scope rules formatting ─────────────────────────────────────────────────
+
+
+def _format_scope_rules(config: AdversaConfig) -> str:
+    """Format scope avoid/focus rules as markdown for prompt injection."""
+    lines: list[str] = []
+    avoid = config.scope.rules.avoid
+    focus = config.scope.rules.focus
+
+    if not avoid and not focus:
+        return ""
+
+    lines.append("## Scope Rules\n")
+
+    if avoid:
+        lines.append("**AVOID these paths/endpoints (do NOT scan, probe, or include in results):**")
+        for rule in avoid:
+            path = rule.url_path or "(host-level)"
+            lines.append(f"- `{path}` ({rule.type}) — {rule.description}")
+        lines.append("")
+
+    if focus:
+        lines.append("**FOCUS on these paths/endpoints (prioritize scanning and deeper analysis):**")
+        for rule in focus:
+            path = rule.url_path or "(host-level)"
+            lines.append(f"- `{path}` ({rule.type}) — {rule.description}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _format_preflight_context(store: ArtifactStore) -> str:
+    """Format preflight results as context for the agent prompt."""
+    if not store.exists("PREFLIGHT_RESULT"):
+        return ""
+
+    preflight = store.read("PREFLIGHT_RESULT")
+    lines: list[str] = ["**Phase 0 Preflight Results (use this to guide your scans):**"]
+
+    # Repo profile — frameworks are especially useful for choosing scan strategies
+    rp = preflight.get("repo_profile")
+    if rp:
+        if rp.get("frameworks"):
+            lines.append(f"- Frameworks detected: {', '.join(rp['frameworks'])}")
+        lines.append(f"- Detection method: {rp.get('detection_method', 'unknown')}, "
+                     f"confidence: {rp.get('confidence', 'unknown')}")
+
+    # Scope manifest — agent needs to know what's in/out of scope
+    sm = preflight.get("scope_manifest")
+    if sm:
+        import json
+        manifest = json.loads(sm) if isinstance(sm, str) else sm
+        if manifest.get("excluded_paths"):
+            lines.append(f"- Excluded paths: {', '.join(manifest['excluded_paths'])}")
+        if manifest.get("excluded_patterns"):
+            lines.append(f"- Excluded patterns: {', '.join(manifest['excluded_patterns'])}")
+
+    # Check results — warn about any failures the agent should know about
+    checks = preflight.get("checks", [])
+    failed = [c for c in checks if c.get("status") == "fail"]
+    if failed:
+        lines.append("- **Preflight warnings:**")
+        for c in failed:
+            lines.append(f"  - {c['name']}: {c.get('detail', 'failed')}")
+
+    return "\n".join(lines) + "\n"
+
+
+# ─── Prompts ──────────────────────────────────────────────────────────────────
+
+_SYSTEM_PROMPT = """\
+You are the **Phase 1 Pre-Recon Scanner** in Adversa, a whitebox AI-powered \
+penetration testing pipeline.
+
+**Pipeline context:**
+- Phase 0 (complete): Preflight identified the target's languages, frameworks, \
+and Semgrep rulesets.
+- **Phase 1 (YOU): Run static analysis and infrastructure scanning.** Your output \
+is the foundation everything downstream depends on.
+- Phase 2 (next): A recon agent uses your INFRA_MAP and TECH_STACK to discover \
+endpoints and establish authenticated sessions.
+- Phase 3 (downstream): Six parallel vulnerability agents consume your output:
+  - **Injection agent** — SEMGREP_RAW + Joern CPG for taint-flow confirmation
+  - **AuthZ agent** — INFRA_MAP endpoints to test BOLA, privilege escalation
+  - **Info Disclosure agent** — TECH_STACK for misconfigured headers, debug endpoints
+  - **SSRF agent** — endpoint inventory + INFRA_MAP for internal service probing
+  - **SAST Triage agent** — cross-references SEMGREP_RAW against source code
+  - **SCA Reachability agent** — SBOM vulnerabilities for reachable code paths
+
+**Why your output quality matters:**
+- Empty SEMGREP_RAW → SAST Triage and Injection agents have nothing to work with.
+- SBOM with 0 vulns because of a missing lockfile → SCA Reachability skips entirely.
+- Incomplete INFRA_MAP → recon agent misses services, AuthZ/SSRF have blind spots.
+- False negatives at Phase 1 propagate as blind spots through the entire pentest.
+
+**Available tools on PATH:**
+- `semgrep` — SAST scanner (supports 30+ languages, custom rulesets)
+- `trivy` — SCA scanner (SBOM, CVE, secret, misconfig scanning)
+- `nmap` — network/port scanner
+- `subfinder` — passive subdomain enumeration
+- `pd-httpx` — ProjectDiscovery HTTP probe / tech detection (NOT Python httpx)
+- `joern-parse` / `joern` — CPG builder for taint-flow analysis (if enabled)
+- `npm` — available for lockfile generation (JS/TS targets)
+- Standard Unix tools: `curl`, `jq`, `grep`, `awk`, etc.
+
+**Hard rules (non-negotiable):**
+- **Save each scan result to the artifact directory immediately** — do NOT wait \
+until the end. Use Bash to write JSON files as you go.
+- **Respect scope avoid/focus rules** — skip endpoints under AVOID, prioritize FOCUS.
+- **Never modify source code** — lockfile generation is OK, code changes are not.
+- **Strip the repo base path** from all file paths in findings for portability.
+- If a tool fails, capture the error, log it, and continue with other tools.
+
+**Soft guidelines (adapt as needed):**
+- The recommended commands below are starting points. You have full discretion to \
+adjust flags, add retries, run additional passes, or use different tool modes \
+based on what you discover about the target.
+- If results are empty or suspicious, investigate WHY and try alternative approaches \
+before accepting the result (wrong path? missing lockfile? unsupported language? \
+wrong scan mode?).
+- If you discover something unexpected (additional services, interesting files, \
+unusual tech stack), capture it in the artifacts — more data is better for \
+downstream agents.
+- Generate missing lockfiles before SCA scanning — downstream agents need \
+dependency data. Use the appropriate package manager for the detected language.
+"""
+
+_USER_PROMPT = """\
+Run Phase 1 pre-recon scans on the target.
+
+**Artifact directory:** `{artifact_dir}`
+```
+mkdir -p {artifact_dir}
+```
+
+**Configuration:**
+- **Repository:** {repo_path}
+- **Target URL:** {base_url}
+- **Target Hosts:** {included_hosts}
+- **Detected Languages:** {languages}
+- **Detected Frameworks:** {frameworks}
+- **Semgrep Rulesets:** {rulesets}
+- **Joern Enabled:** {joern_enabled}
+
+{preflight_context}
+
+{scope_rules}\
+---
+
+## 1. SAST — Semgrep → `{artifact_dir}/SEMGREP_RAW.json`
+
+**Goal:** Find all static analysis findings in the repo. Downstream Injection and \
+SAST Triage agents depend on comprehensive coverage.
+
+**Recommended approach:**
+```
+semgrep scan {ruleset_flags} --json --quiet --metrics=off --timeout 120 {repo_path} \
+  > {artifact_dir}/SEMGREP_RAW.json 2>/dev/null
+```
+
+**You may adapt:** Add extra rulesets if you notice frameworks not covered by the \
+defaults (e.g. `--config p/django` for Python/Django, `--config p/react` for React, \
+`--config p/jwt` for JWT handling). Adjust `--timeout` for large repos. If Semgrep \
+reports 0 findings, investigate and retry with broader rulesets before accepting.
+
+After saving, read the JSON to count findings by severity and files scanned.
+
+## 2. SCA — Trivy → `{artifact_dir}/SBOM.json`
+
+**Goal:** Identify all known CVEs in dependencies. The SCA Reachability agent needs \
+a populated vulnerability list.
+
+**Recommended approach:**
+1. Check for lockfiles. If none exist, generate one:
+   - JS/TS: `cd {repo_path} && npm install --package-lock-only --ignore-scripts`
+   - Python: `cd {repo_path} && pip freeze > requirements.txt` (or `uv lock`)
+   - Go: `cd {repo_path} && go mod tidy`
+   - Other: use the appropriate package manager
+2. Run Trivy:
+```
+trivy fs --format json --severity CRITICAL,HIGH,MEDIUM --quiet {repo_path} \
+  > {artifact_dir}/SBOM.json 2>/dev/null
+```
+
+**You may adapt:** Add `--scanners vuln,secret,misconfig` if you want broader \
+coverage. Use `--list-all-pkgs` to include all packages (not just vulnerable ones) \
+for a more complete SBOM. If Trivy returns 0 vulns but a lockfile exists, try \
+`trivy fs --scanners vuln --format json {repo_path}` without severity filter.
+
+## 3. Infrastructure → `{artifact_dir}/INFRA_MAP.json` + `{artifact_dir}/TECH_STACK.json`
+
+**Goal:** Map all open ports, services, and technologies. Downstream Recon, AuthZ, \
+SSRF, and Info Disclosure agents depend on complete infrastructure visibility.
+
+**Recommended tools:**
+- **nmap** — port scanning: `nmap -sV -T4 --top-ports 1000 -oX - {{host}}`
+- **subfinder** — subdomain enumeration (skip for localhost/Docker/IP targets): \
+`subfinder -d {{domain}} -silent`
+- **pd-httpx** — HTTP probing and tech detection: \
+`echo "{{targets}}" | pd-httpx -json -tech-detect -status-code -title -server -silent`
+
+**You may adapt:**
+- For targets behind WAFs or with rate limiting, reduce nmap timing (`-T3` or `-T2`).
+- If `--top-ports 1000` misses expected services, try a full port scan (`-p-`) on \
+specific hosts.
+- Add `-sU --top-ports 20` for UDP scanning on high-value targets.
+- If pd-httpx fails or is unavailable, infer tech stack from nmap service banners, \
+HTTP response headers (`curl -sI`), and repo source code.
+- Probe each discovered HTTP port for common paths (`/robots.txt`, `/sitemap.xml`, \
+`/.well-known/`, `/api/`, `/swagger.json`, `/health`) to enrich the INFRA_MAP.
+
+**Artifact format — INFRA_MAP.json:**
+```json
+{{
+  "hosts": [{{"hostname": "...", "ports": [{{"port": N, "protocol": "tcp", \
+"service": "...", "version": "...", "product": "..."}}]}}],
+  "total_hosts": N,
+  "total_open_ports": N,
+  "warnings": ["..."]
+}}
+```
+
+**Artifact format — TECH_STACK.json:**
+```json
+{{
+  "technologies": ["Node.js", "Express", ...],
+  "servers": ["nginx/1.24", ...],
+  "subdomains": ["api.example.com", ...]
+}}
+```
+
+## 4. Joern CPG Build (conditional)
+
+{joern_instructions}
+
+## Final Summary
+
+Do NOT return raw scan data — it's already saved in the artifact files. \
+Return ONLY a lightweight summary:
+- `semgrep_findings_count`: total findings
+- `sca_vulns_count`: total CVEs from Trivy
+- `infra_open_ports`: total open ports
+- `joern_success`: true/false
+- `summary`: one paragraph — what was found, what downstream agents should \
+focus on, any gaps/limitations, and your confidence in the scan coverage
+"""
+
+
+# ─── Entry point ──────────────────────────────────────────────────────────────
+
+
+async def run_pre_recon(config: AdversaConfig, store: ArtifactStore) -> dict[str, Any]:
+    """
+    Run a single LLM agent that executes all Phase 1 scans, writes artifacts
+    directly to the store directory via Bash, and returns a lightweight summary.
+
+    Returns the summary dict, or a fallback dict on agent failure.
+    """
+    repo_profile = _load_repo_profile(store, config)
+    languages = repo_profile.get("languages", [])
+    rulesets = repo_profile.get("semgrep_rulesets", ["p/owasp-top-ten"])
+    joern_enabled = config.repo.joern_enabled
+
+    # Build ruleset flags for semgrep command
+    ruleset_flags = " ".join(f"--config {r}" for r in rulesets)
+
+    # Joern instructions
+    if joern_enabled:
+        lang = languages[0] if languages else "unknown"
+        lang_map = {
+            "python": "pythonsrc", "java": "javasrc",
+            "javascript": "jssrc", "typescript": "jssrc", "go": "golang",
+        }
+        joern_lang = lang_map.get(lang, "")
+        lang_flag = f"--language {joern_lang}" if joern_lang else ""
+        joern_instructions = f"""\
+Joern is ENABLED. Build the Code Property Graph:
+```
+joern-parse {config.repo.path} --output {store._dir}/cpg.bin {lang_flag}
+```
+Then write the result:
+```
+cat > {store._dir}/JOERN_CPG_PATH.json << 'JOERN_EOF'
+{{"success": true, "cpg_path": "{store._dir}/cpg.bin", "error": null}}
+JOERN_EOF
+```
+If it fails, write: `{{"success": false, "cpg_path": null, "error": "...the error..."}}`"""
+    else:
+        joern_instructions = f"""\
+Joern is DISABLED. Write the skip result:
+```
+cat > {store._dir}/JOERN_CPG_PATH.json << 'JOERN_EOF'
+{{"success": false, "cpg_path": null, "error": "Joern disabled in config"}}
+JOERN_EOF
+```"""
+
+    # Format scope rules and preflight context
+    scope_rules = _format_scope_rules(config)
+    preflight_context = _format_preflight_context(store)
+    frameworks = repo_profile.get("frameworks", [])
+
+    # Artifact directory path the agent will write to
+    artifact_dir = str(store._dir)
+
+    prompt = _USER_PROMPT.format(
+        repo_path=config.repo.path,
+        base_url=config.target.base_url,
+        included_hosts=", ".join(config.target.included_hosts),
+        languages=", ".join(languages) if languages else "unknown",
+        frameworks=", ".join(frameworks) if frameworks else "none detected",
+        rulesets=", ".join(rulesets),
+        ruleset_flags=ruleset_flags,
+        joern_enabled=joern_enabled,
+        joern_instructions=joern_instructions,
+        scope_rules=scope_rules,
+        preflight_context=preflight_context,
+        artifact_dir=artifact_dir,
+    )
+
+    options = ClaudeAgentOptions(
+        model=config.llm.model_name,
+        system_prompt=_SYSTEM_PROMPT,
+        allowed_tools=_ALLOWED_TOOLS,
+        max_turns=50,
+        cwd="/app" if _is_docker() else ".",
+        env=build_agent_env(config),
+        permission_mode="bypassPermissions",
+        output_format=_OUTPUT_FORMAT,
+    )
+
+    logger.info("Starting pre-recon agent (model=%s, repo=%s)", config.llm.model_name, config.repo.path)
+
+    result = await run_agent(
+        options=options,
+        prompt=prompt,
+        config=config,
+    )
+
+    output = result.get("structured_output")
+    if not output:
+        logger.error("Pre-recon agent returned no structured output: %s", result.get("error"))
+        output = _fallback_output(result.get("error", "Agent returned no output"))
+
+    # Verify artifacts were written by the agent
+    _verify_artifacts(store)
+
+    logger.info("Pre-recon agent complete: %s", output.get("summary", "no summary"))
+    return output
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _load_repo_profile(store: ArtifactStore, config: AdversaConfig) -> dict:
+    """Load repo profile from artifact store, falling back to config defaults."""
+    if store.exists("PREFLIGHT_RESULT"):
+        preflight = store.read("PREFLIGHT_RESULT")
+        repo_profile = preflight.get("repo_profile")
+        if repo_profile:
+            return repo_profile
+    return {
+        "languages": [config.repo.language] if config.repo.language else [],
+        "semgrep_rulesets": config.repo.semgrep_rulesets or ["p/owasp-top-ten"],
+        "joern_enabled": config.repo.joern_enabled,
+    }
+
+
+def _is_docker() -> bool:
+    """Detect if running inside Docker."""
+    try:
+        with open("/proc/1/cgroup") as f:
+            return "docker" in f.read()
+    except Exception:
+        return False
+
+
+def _verify_artifacts(store: ArtifactStore) -> None:
+    """Check that the agent wrote expected artifacts. Log warnings for missing ones."""
+    expected = ["SEMGREP_RAW", "SBOM", "INFRA_MAP", "TECH_STACK", "JOERN_CPG_PATH"]
+    for artifact in expected:
+        if not store.exists(artifact):
+            logger.warning("Pre-recon agent did not write artifact: %s", artifact)
+
+
+def _fallback_output(error: str) -> dict:
+    """Return a minimal valid summary dict when the agent fails entirely."""
+    return {
+        "semgrep_findings_count": 0,
+        "semgrep_error": error,
+        "sca_vulns_count": 0,
+        "sca_lockfile_found": False,
+        "sca_error": error,
+        "infra_open_ports": 0,
+        "joern_success": False,
+        "joern_error": error,
+        "summary": f"Pre-recon agent failed: {error}",
+    }

--- a/src/artifacts/schemas.py
+++ b/src/artifacts/schemas.py
@@ -49,3 +49,104 @@ class PreflightResult:
     errors: list[str] = field(default_factory=list)
     scope_manifest: dict = field(default_factory=dict)
     repo_profile: RepoProfile | None = None
+
+
+# ─── Phase 1 ──────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class SemgrepFinding:
+    """Single Semgrep finding with normalized paths and metadata."""
+    rule_id: str
+    path: str
+    start_line: int
+    end_line: int
+    severity: str       # "ERROR" | "WARNING" | "INFO"
+    message: str
+    cwe: list[str] = field(default_factory=list)
+    owasp: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SemgrepRaw:
+    """Aggregate SAST result — SEMGREP_RAW artifact."""
+    findings: list[SemgrepFinding]
+    total: int
+    by_severity: dict[str, int] = field(default_factory=dict)
+    rulesets_used: list[str] = field(default_factory=list)
+    files_scanned: int = 0
+    warnings: list[str] = field(default_factory=list)
+    error: str | None = None
+
+
+@dataclass
+class ScaVulnerability:
+    """Single CVE from Trivy scan."""
+    cve_id: str
+    package: str
+    installed_version: str
+    severity: str           # "CRITICAL" | "HIGH" | "MEDIUM"
+    fixed_version: str | None = None
+    cvss: float | None = None
+    title: str = ""
+    reachable: bool | None = None  # Phase 3f fills this in
+
+
+@dataclass
+class ScaResult:
+    """Aggregate SCA result — SBOM artifact."""
+    vulnerabilities: list[ScaVulnerability]
+    total: int
+    by_severity: dict[str, int] = field(default_factory=dict)
+    lockfile_found: bool = False
+    lockfile_type: str | None = None
+    warnings: list[str] = field(default_factory=list)
+    error: str | None = None
+
+
+@dataclass
+class HostPort:
+    """Single open port on a host."""
+    port: int
+    protocol: str = "tcp"
+    service: str = ""
+    version: str = ""
+
+
+@dataclass
+class InfraHost:
+    """Host with its open ports from nmap scan."""
+    hostname: str
+    ports: list[HostPort] = field(default_factory=list)
+
+
+@dataclass
+class InfraMap:
+    """Aggregate infrastructure scan result — INFRA_MAP artifact."""
+    hosts: list[InfraHost]
+    total_hosts: int = 0
+    total_open_ports: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass
+class TechStack:
+    """Technology fingerprinting from httpx — TECH_STACK artifact."""
+    technologies: list[str] = field(default_factory=list)
+    servers: list[str] = field(default_factory=list)
+    subdomains: list[str] = field(default_factory=list)
+
+
+@dataclass
+class JoernCpgResult:
+    """Joern CPG build result — JOERN_CPG_PATH artifact."""
+    success: bool
+    cpg_path: str | None = None
+    error: str | None = None
+
+
+@dataclass
+class PreReconResult:
+    """Aggregate Phase 1 result returned by PreReconWorkflow."""
+    status: str  # "complete" | "partial"
+    errors: list[str] = field(default_factory=list)

--- a/src/artifacts/store.py
+++ b/src/artifacts/store.py
@@ -1,0 +1,33 @@
+"""
+Artifact store — typed JSON persistence for inter-phase communication.
+
+All artifacts are written to ./runs/{engagement_id}/artifacts/{artifact_type}.json
+and read by subsequent phases. Docker volume ./runs:/app/runs is already mounted.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+class ArtifactStore:
+    """Read/write JSON artifacts scoped to an engagement run."""
+
+    def __init__(self, engagement_id: str, base_dir: str = "./runs") -> None:
+        self._dir = Path(base_dir) / engagement_id / "artifacts"
+
+    def write(self, artifact_type: str, data: dict) -> Path:
+        """Write a JSON artifact. Creates directories as needed."""
+        self._dir.mkdir(parents=True, exist_ok=True)
+        path = self._dir / f"{artifact_type}.json"
+        path.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+        return path
+
+    def read(self, artifact_type: str) -> dict:
+        """Read a JSON artifact. Raises FileNotFoundError if missing."""
+        path = self._dir / f"{artifact_type}.json"
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def exists(self, artifact_type: str) -> bool:
+        """Check if an artifact exists."""
+        return (self._dir / f"{artifact_type}.json").is_file()

--- a/src/services/joern_query.py
+++ b/src/services/joern_query.py
@@ -1,0 +1,54 @@
+"""
+Joern CPG query helper — executes Joern queries against a built CPG.
+
+Used by Phase 3 agents via the query_joern MCP tool.
+NOT called during Phase 1 — built now for Phase 3 readiness.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT_SECONDS = 120
+
+
+async def run_joern_query(cpg_path: str, query: str) -> str:
+    """
+    Execute a Joern query against the given CPG.
+
+    Args:
+        cpg_path: Path to the CPG binary (e.g. ./runs/{id}/cpg.bin).
+        query: Joern/CPGQL query string.
+
+    Returns:
+        Query result as a string.
+
+    Raises:
+        RuntimeError: If Joern exits with a non-zero code.
+        asyncio.TimeoutError: If query exceeds timeout.
+    """
+    # Build the Joern script that loads the CPG and runs the query
+    script = f'importCpg("{cpg_path}")\n{query}'
+
+    cmd = ["joern", "--script", "/dev/stdin"]
+
+    logger.info("Running Joern query on %s", cpg_path)
+
+    proc = await asyncio.wait_for(
+        asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        ),
+        timeout=_TIMEOUT_SECONDS,
+    )
+    stdout, stderr = await proc.communicate(input=script.encode())
+
+    if proc.returncode != 0:
+        error_msg = stderr.decode(errors="replace").strip()
+        raise RuntimeError(f"Joern query failed (exit {proc.returncode}): {error_msg}")
+
+    return stdout.decode(errors="replace").strip()

--- a/src/services/preflight.py
+++ b/src/services/preflight.py
@@ -8,6 +8,7 @@ never short-circuits after the first error.
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 from pathlib import Path
 
 import httpx
@@ -17,7 +18,7 @@ from src.config.models import AdversaConfig
 from src.scope.enforcer import ScopeEnforcer
 
 # Tools that must be present in the container for scans to run.
-_BASE_REQUIRED_TOOLS = ["semgrep", "trivy", "nmap", "subfinder", "httpx"]
+_BASE_REQUIRED_TOOLS = ["semgrep", "trivy", "nmap", "subfinder", "pd-httpx", "npm"]
 _JOERN_TOOL = "joern"
 
 
@@ -107,10 +108,17 @@ async def run_preflight(config: AdversaConfig) -> PreflightResult:
         from src.services.repo_introspection import run_repo_introspection
         repo_profile = await run_repo_introspection(config)
 
-    return PreflightResult(
+    result = PreflightResult(
         status="fail" if failed else "pass",
         checks=checks,
         errors=[c.detail for c in failed if c.detail],
         scope_manifest=scope_manifest,
         repo_profile=repo_profile,
     )
+
+    # Write artifacts to store for Phase 1 consumption
+    from src.artifacts.store import ArtifactStore
+    store = ArtifactStore(config.meta.engagement_id)
+    store.write("PREFLIGHT_RESULT", dataclasses.asdict(result))
+
+    return result

--- a/src/temporal/activities.py
+++ b/src/temporal/activities.py
@@ -10,10 +10,14 @@ Retry policy (3 attempts, exponential backoff) is set on the workflow side.
 """
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import json
+import logging
 
 from temporalio import activity
+
+logger = logging.getLogger(__name__)
 
 # Tracing is initialised lazily per-thread via agent_runner.py when
 # config.tracing.enabled=true. No global setup needed here — the runner
@@ -42,8 +46,27 @@ async def run_preflight_phase(input: WorkflowInput) -> WorkflowResult:
 
 @activity.defn
 async def run_pre_recon_phase(input: WorkflowInput) -> WorkflowResult:
-    """Phase 1 — tool-only recon: nmap, subfinder, httpx, Semgrep, Trivy, Joern CPG build."""
-    return WorkflowResult(status="complete")  # stub — implement in Phase 1 ticket
+    """Phase 1 — agent-driven pre-recon: semgrep, trivy, nmap, subfinder, httpx, joern."""
+    from src.artifacts.store import ArtifactStore
+    from src.agents.pre_recon import run_pre_recon
+
+    store = ArtifactStore(input.config.meta.engagement_id)
+    try:
+        output = await run_pre_recon(input.config, store)
+    except asyncio.CancelledError:
+        logger.info("Pre-recon activity cancelled by workflow")
+        return WorkflowResult(status="aborted", reason="Cancelled by user")
+
+    # Check for any scanner-level errors
+    errors = []
+    for key in ("semgrep_error", "sca_error", "joern_error"):
+        err = output.get(key)
+        if err:
+            errors.append(f"{key.replace('_error', '')}: {err}")
+
+    if errors:
+        return WorkflowResult(status="partial", reason="; ".join(errors))
+    return WorkflowResult(status="complete")
 
 
 @activity.defn

--- a/src/temporal/client.py
+++ b/src/temporal/client.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--phase",
         default=None,
-        choices=["preflight"],
+        choices=["preflight", "prerecon"],
         help="Focus output on a specific phase result (workflow always runs in full)",
     )
     args = parser.parse_args()
@@ -76,6 +76,53 @@ if __name__ == "__main__":
             # Print the PreflightResult JSON so dev can inspect Phase 0 output
             data = json.loads(result.preflight_json)
             print(json.dumps(data, indent=2))
+        elif args.phase == "prerecon":
+            # Print Phase 1 artifact summary from artifact store
+            from src.artifacts.store import ArtifactStore
+            store = ArtifactStore(config.meta.engagement_id)
+            summary = {}
+            all_warnings: list[str] = []
+            for artifact in ["SEMGREP_RAW", "SBOM", "INFRA_MAP", "TECH_STACK", "JOERN_CPG_PATH"]:
+                if store.exists(artifact):
+                    data = store.read(artifact)
+                    # Collect warnings from all artifacts
+                    artifact_warnings = data.get("warnings", [])
+                    for w in artifact_warnings:
+                        all_warnings.append(f"[{artifact}] {w}")
+                    # Show counts/status, not full data
+                    if artifact == "SEMGREP_RAW":
+                        summary[artifact] = {
+                            "total": data.get("total"),
+                            "files_scanned": data.get("files_scanned", 0),
+                            "by_severity": data.get("by_severity"),
+                            "rulesets_used": data.get("rulesets_used"),
+                            "error": data.get("error"),
+                        }
+                    elif artifact == "SBOM":
+                        summary[artifact] = {
+                            "total": data.get("total"),
+                            "by_severity": data.get("by_severity"),
+                            "lockfile_found": data.get("lockfile_found"),
+                            "lockfile_type": data.get("lockfile_type"),
+                            "error": data.get("error"),
+                        }
+                    elif artifact == "INFRA_MAP":
+                        summary[artifact] = {"total_hosts": data.get("total_hosts"), "total_open_ports": data.get("total_open_ports")}
+                    elif artifact == "TECH_STACK":
+                        summary[artifact] = {"technologies": data.get("technologies", []), "servers": data.get("servers", [])}
+                    elif artifact == "JOERN_CPG_PATH":
+                        summary[artifact] = {"success": data.get("success"), "error": data.get("error")}
+                else:
+                    summary[artifact] = {"status": "missing"}
+                    all_warnings.append(f"[{artifact}] Artifact not produced — scanner may have crashed.")
+            output = {
+                "status": result.status,
+                "reason": result.reason,
+                "artifacts": summary,
+            }
+            if all_warnings:
+                output["warnings"] = all_warnings
+            print(json.dumps(output, indent=2))
         else:
             print(json.dumps({"status": result.status, "reason": result.reason}, indent=2))
 

--- a/src/temporal/workflows.py
+++ b/src/temporal/workflows.py
@@ -3,7 +3,7 @@ Adversa top-level Temporal workflow.
 
 PentestPipelineWorkflow orchestrates all phases in order:
   Phase 0 → preflight
-  Phase 1 → pre-recon (tool-only)
+  Phase 1 → pre-recon (agent-driven)
   Phase 2 → recon (LLM)
   Phase 3 → parallel vulnerability analysis (6 agents)
   Phase 4 → exploitation (Pro only)
@@ -14,6 +14,12 @@ Unimplemented phases are stubs that return WorkflowResult(status="complete")
 immediately. Replace each stub with real logic as the phase is built.
 This means the full workflow can be run end-to-end at any stage of development
 without needing separate test workflows.
+
+Timeout tiers (modelled after Shannon's pattern):
+  - Preflight: short (2min) — no LLM, fast validation
+  - Agent activities: extended (2h start-to-close, 60min heartbeat) — SDK blocks
+    event loop during tool calls, so heartbeats can't fire mid-execution
+  - Reporting: medium (30min) — template rendering, no long tool calls
 """
 from __future__ import annotations
 
@@ -41,14 +47,44 @@ with workflow.unsafe.imports_passed_through():
         run_ssrf_analysis,
     )
 
-_RETRY_POLICY = RetryPolicy(
+# ─── Retry policies ──────────────────────────────────────────────────────────
+
+_PREFLIGHT_RETRY = RetryPolicy(
     maximum_attempts=3,
     initial_interval=timedelta(seconds=1),
     backoff_coefficient=2.0,
 )
 
-_PHASE3_TIMEOUT = timedelta(minutes=60)
-_PHASE3_HEARTBEAT = timedelta(minutes=2)
+_AGENT_RETRY = RetryPolicy(
+    maximum_attempts=50,
+    initial_interval=timedelta(minutes=5),
+    maximum_interval=timedelta(minutes=30),
+    backoff_coefficient=2.0,
+    non_retryable_error_types=[
+        "AuthenticationError",
+        "PermissionError",
+        "InvalidRequestError",
+        "ConfigurationError",
+    ],
+)
+
+_REPORT_RETRY = RetryPolicy(
+    maximum_attempts=3,
+    initial_interval=timedelta(seconds=5),
+    backoff_coefficient=2.0,
+)
+
+# ─── Timeout tiers ───────────────────────────────────────────────────────────
+# Agent activities use extended heartbeat (60min) because claude-agent-sdk
+# blocks the event loop during tool calls — no heartbeats can fire mid-execution.
+
+_PREFLIGHT_TIMEOUT = timedelta(minutes=5)
+_PREFLIGHT_HEARTBEAT = timedelta(minutes=2)
+
+_AGENT_TIMEOUT = timedelta(hours=2)
+_AGENT_HEARTBEAT = timedelta(minutes=60)
+
+_REPORT_TIMEOUT = timedelta(minutes=30)
 
 
 @workflow.defn
@@ -59,8 +95,9 @@ class PentestPipelineWorkflow:
         preflight = await workflow.execute_activity(
             run_preflight_phase,
             input,
-            start_to_close_timeout=timedelta(minutes=5),
-            retry_policy=_RETRY_POLICY,
+            start_to_close_timeout=_PREFLIGHT_TIMEOUT,
+            heartbeat_timeout=_PREFLIGHT_HEARTBEAT,
+            retry_policy=_PREFLIGHT_RETRY,
         )
         if preflight.status == "aborted":
             return WorkflowResult(
@@ -69,22 +106,22 @@ class PentestPipelineWorkflow:
                 preflight_json=preflight.preflight_json,
             )
 
-        # ── Phase 1: tool-only pre-recon ──────────────────────────────────────
+        # ── Phase 1: agent-driven pre-recon ──────────────────────────────────
         await workflow.execute_activity(
             run_pre_recon_phase,
             input,
-            start_to_close_timeout=timedelta(minutes=30),
-            heartbeat_timeout=timedelta(minutes=2),
-            retry_policy=_RETRY_POLICY,
+            start_to_close_timeout=_AGENT_TIMEOUT,
+            heartbeat_timeout=_AGENT_HEARTBEAT,
+            retry_policy=_AGENT_RETRY,
         )
 
         # ── Phase 2: LLM recon ────────────────────────────────────────────────
         await workflow.execute_activity(
             run_recon_phase,
             input,
-            start_to_close_timeout=timedelta(minutes=45),
-            heartbeat_timeout=timedelta(minutes=2),
-            retry_policy=_RETRY_POLICY,
+            start_to_close_timeout=_AGENT_TIMEOUT,
+            heartbeat_timeout=_AGENT_HEARTBEAT,
+            retry_policy=_AGENT_RETRY,
         )
 
         # ── Phase 3: parallel vulnerability analysis ──────────────────────────
@@ -92,44 +129,44 @@ class PentestPipelineWorkflow:
             workflow.execute_activity(
                 run_injection_analysis,
                 input,
-                start_to_close_timeout=_PHASE3_TIMEOUT,
-                heartbeat_timeout=_PHASE3_HEARTBEAT,
-                retry_policy=_RETRY_POLICY,
+                start_to_close_timeout=_AGENT_TIMEOUT,
+                heartbeat_timeout=_AGENT_HEARTBEAT,
+                retry_policy=_AGENT_RETRY,
             ),
             workflow.execute_activity(
                 run_authz_analysis,
                 input,
-                start_to_close_timeout=_PHASE3_TIMEOUT,
-                heartbeat_timeout=_PHASE3_HEARTBEAT,
-                retry_policy=_RETRY_POLICY,
+                start_to_close_timeout=_AGENT_TIMEOUT,
+                heartbeat_timeout=_AGENT_HEARTBEAT,
+                retry_policy=_AGENT_RETRY,
             ),
             workflow.execute_activity(
                 run_info_disclosure_analysis,
                 input,
-                start_to_close_timeout=_PHASE3_TIMEOUT,
-                heartbeat_timeout=_PHASE3_HEARTBEAT,
-                retry_policy=_RETRY_POLICY,
+                start_to_close_timeout=_AGENT_TIMEOUT,
+                heartbeat_timeout=_AGENT_HEARTBEAT,
+                retry_policy=_AGENT_RETRY,
             ),
             workflow.execute_activity(
                 run_ssrf_analysis,
                 input,
-                start_to_close_timeout=_PHASE3_TIMEOUT,
-                heartbeat_timeout=_PHASE3_HEARTBEAT,
-                retry_policy=_RETRY_POLICY,
+                start_to_close_timeout=_AGENT_TIMEOUT,
+                heartbeat_timeout=_AGENT_HEARTBEAT,
+                retry_policy=_AGENT_RETRY,
             ),
             workflow.execute_activity(
                 run_sast_triage,
                 input,
-                start_to_close_timeout=_PHASE3_TIMEOUT,
-                heartbeat_timeout=_PHASE3_HEARTBEAT,
-                retry_policy=_RETRY_POLICY,
+                start_to_close_timeout=_AGENT_TIMEOUT,
+                heartbeat_timeout=_AGENT_HEARTBEAT,
+                retry_policy=_AGENT_RETRY,
             ),
             workflow.execute_activity(
                 run_sca_reachability,
                 input,
-                start_to_close_timeout=_PHASE3_TIMEOUT,
-                heartbeat_timeout=_PHASE3_HEARTBEAT,
-                retry_policy=_RETRY_POLICY,
+                start_to_close_timeout=_AGENT_TIMEOUT,
+                heartbeat_timeout=_AGENT_HEARTBEAT,
+                retry_policy=_AGENT_RETRY,
             ),
             return_exceptions=True,
         )
@@ -139,8 +176,8 @@ class PentestPipelineWorkflow:
             return await workflow.execute_activity(
                 run_findings_report,
                 input,
-                start_to_close_timeout=timedelta(minutes=15),
-                retry_policy=_RETRY_POLICY,
+                start_to_close_timeout=_REPORT_TIMEOUT,
+                retry_policy=_REPORT_RETRY,
             )
 
         # ── Pro path: Phase 4 — conditional parallel exploitation ─────────────
@@ -148,9 +185,9 @@ class PentestPipelineWorkflow:
             workflow.execute_activity(
                 run_exploit_agent,
                 input,
-                start_to_close_timeout=timedelta(minutes=60),
-                heartbeat_timeout=timedelta(minutes=2),
-                retry_policy=_RETRY_POLICY,
+                start_to_close_timeout=_AGENT_TIMEOUT,
+                heartbeat_timeout=_AGENT_HEARTBEAT,
+                retry_policy=_AGENT_RETRY,
             )
             for result in vuln_results
             if isinstance(result, WorkflowResult) and result.status != "aborted"
@@ -161,6 +198,6 @@ class PentestPipelineWorkflow:
         return await workflow.execute_activity(
             run_pentest_report,
             input,
-            start_to_close_timeout=timedelta(minutes=15),
-            retry_policy=_RETRY_POLICY,
+            start_to_close_timeout=_REPORT_TIMEOUT,
+            retry_policy=_REPORT_RETRY,
         )

--- a/tests/test_artifact_store.py
+++ b/tests/test_artifact_store.py
@@ -1,0 +1,57 @@
+"""Tests for ArtifactStore — write/read roundtrip, existence, isolation."""
+from __future__ import annotations
+
+import pytest
+
+from src.artifacts.store import ArtifactStore
+
+
+def test_write_read_roundtrip(tmp_path):
+    store = ArtifactStore("eng-001", base_dir=str(tmp_path))
+    data = {"key": "value", "nested": {"a": 1}}
+
+    path = store.write("TEST_ARTIFACT", data)
+
+    assert path.exists()
+    assert store.read("TEST_ARTIFACT") == data
+
+
+def test_exists_returns_false_when_missing(tmp_path):
+    store = ArtifactStore("eng-001", base_dir=str(tmp_path))
+    assert store.exists("NONEXISTENT") is False
+
+
+def test_exists_returns_true_after_write(tmp_path):
+    store = ArtifactStore("eng-001", base_dir=str(tmp_path))
+    store.write("MY_ARTIFACT", {"x": 1})
+    assert store.exists("MY_ARTIFACT") is True
+
+
+def test_read_missing_raises_file_not_found(tmp_path):
+    store = ArtifactStore("eng-001", base_dir=str(tmp_path))
+    with pytest.raises(FileNotFoundError):
+        store.read("MISSING")
+
+
+def test_creates_directories_on_write(tmp_path):
+    store = ArtifactStore("eng-deep/nested", base_dir=str(tmp_path))
+    store.write("DATA", {"ok": True})
+    assert store.read("DATA") == {"ok": True}
+
+
+def test_engagement_isolation(tmp_path):
+    store_a = ArtifactStore("eng-a", base_dir=str(tmp_path))
+    store_b = ArtifactStore("eng-b", base_dir=str(tmp_path))
+
+    store_a.write("SHARED_NAME", {"from": "a"})
+    store_b.write("SHARED_NAME", {"from": "b"})
+
+    assert store_a.read("SHARED_NAME") == {"from": "a"}
+    assert store_b.read("SHARED_NAME") == {"from": "b"}
+
+
+def test_overwrite_existing_artifact(tmp_path):
+    store = ArtifactStore("eng-001", base_dir=str(tmp_path))
+    store.write("DATA", {"version": 1})
+    store.write("DATA", {"version": 2})
+    assert store.read("DATA") == {"version": 2}

--- a/tests/test_pre_recon.py
+++ b/tests/test_pre_recon.py
@@ -1,0 +1,243 @@
+"""Tests for Phase 1 pre-recon agent — artifact verification, fallback, repo profile, scope rules."""
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test")
+
+from src.agents.pre_recon import (
+    _fallback_output,
+    _format_scope_rules,
+    _load_repo_profile,
+    _verify_artifacts,
+)
+from src.artifacts.store import ArtifactStore
+from src.config.models import (
+    AdversaConfig,
+    AuthConfig,
+    LLMConfig,
+    MetaConfig,
+    PipelineConfig,
+    RepoConfig,
+    ScopeConfig,
+    ScopeRule,
+    ScopeRules,
+    TargetConfig,
+)
+
+
+def _make_config(joern_enabled: bool = True, avoid=None, focus=None) -> AdversaConfig:
+    rules = ScopeRules(avoid=avoid or [], focus=focus or [])
+    return AdversaConfig(
+        meta=MetaConfig(project="test", engagement_id="adv-test-prerecon"),
+        llm=LLMConfig(model_name="claude-sonnet-4-6", api_key_env="ANTHROPIC_API_KEY"),
+        target=TargetConfig(base_url="https://example.com", included_hosts=["example.com"]),
+        authentication=AuthConfig(login_type="none"),
+        scope=ScopeConfig(rules=rules),
+        pipeline=PipelineConfig(enabled=["injection"]),
+        repo=RepoConfig(path="/tmp/repo", joern_enabled=joern_enabled),
+    )
+
+
+# ─── _load_repo_profile ─────────────────────────────────────────────────────
+
+
+def test_load_repo_profile_from_store(tmp_path):
+    config = _make_config()
+    store = ArtifactStore(config.meta.engagement_id, base_dir=str(tmp_path))
+    store.write("PREFLIGHT_RESULT", {
+        "status": "pass",
+        "repo_profile": {
+            "languages": ["python"],
+            "semgrep_rulesets": ["p/owasp-top-ten", "p/python"],
+            "joern_enabled": True,
+        },
+    })
+
+    profile = _load_repo_profile(store, config)
+    assert profile["languages"] == ["python"]
+    assert "p/python" in profile["semgrep_rulesets"]
+
+
+def test_load_repo_profile_fallback(tmp_path):
+    config = _make_config()
+    store = ArtifactStore(config.meta.engagement_id, base_dir=str(tmp_path))
+
+    profile = _load_repo_profile(store, config)
+    assert profile["semgrep_rulesets"] == ["p/owasp-top-ten"]
+    assert profile["joern_enabled"] is True
+
+
+def test_load_repo_profile_with_config_language(tmp_path):
+    config = AdversaConfig(
+        meta=MetaConfig(project="test", engagement_id="adv-test-prerecon"),
+        llm=LLMConfig(model_name="claude-sonnet-4-6", api_key_env="ANTHROPIC_API_KEY"),
+        target=TargetConfig(base_url="https://example.com", included_hosts=["example.com"]),
+        authentication=AuthConfig(login_type="none"),
+        scope=ScopeConfig(rules=ScopeRules()),
+        pipeline=PipelineConfig(enabled=["injection"]),
+        repo=RepoConfig(path="/tmp/repo", language="java", semgrep_rulesets=["p/java", "p/spring"]),
+    )
+    store = ArtifactStore(config.meta.engagement_id, base_dir=str(tmp_path))
+
+    profile = _load_repo_profile(store, config)
+    assert profile["languages"] == ["java"]
+    assert profile["semgrep_rulesets"] == ["p/java", "p/spring"]
+
+
+def test_load_repo_profile_null_repo_profile(tmp_path):
+    config = _make_config()
+    store = ArtifactStore(config.meta.engagement_id, base_dir=str(tmp_path))
+    store.write("PREFLIGHT_RESULT", {"status": "pass", "repo_profile": None})
+
+    profile = _load_repo_profile(store, config)
+    assert profile["semgrep_rulesets"] == ["p/owasp-top-ten"]
+
+
+# ─── _format_scope_rules ───────────────────────────────────────────────────
+
+
+def test_format_scope_rules_empty():
+    config = _make_config()
+    assert _format_scope_rules(config) == ""
+
+
+def test_format_scope_rules_avoid_only():
+    config = _make_config(avoid=[
+        ScopeRule(description="Skip health", type="path", url_path="/health"),
+    ])
+    result = _format_scope_rules(config)
+    assert "AVOID" in result
+    assert "/health" in result
+    assert "Skip health" in result
+    assert "FOCUS" not in result
+
+
+def test_format_scope_rules_focus_only():
+    config = _make_config(focus=[
+        ScopeRule(description="Focus on API", type="path_pattern", url_path="/api/*"),
+    ])
+    result = _format_scope_rules(config)
+    assert "FOCUS" in result
+    assert "/api/*" in result
+    assert "AVOID" not in result
+
+
+def test_format_scope_rules_both():
+    config = _make_config(
+        avoid=[ScopeRule(description="Skip health", type="path", url_path="/health")],
+        focus=[ScopeRule(description="Focus on API", type="path_pattern", url_path="/api/*")],
+    )
+    result = _format_scope_rules(config)
+    assert "AVOID" in result
+    assert "FOCUS" in result
+    assert "/health" in result
+    assert "/api/*" in result
+
+
+# ─── _verify_artifacts ──────────────────────────────────────────────────────
+
+
+def test_verify_artifacts_all_present(tmp_path):
+    store = ArtifactStore("eng-001", base_dir=str(tmp_path))
+    for name in ["SEMGREP_RAW", "SBOM", "INFRA_MAP", "TECH_STACK", "JOERN_CPG_PATH"]:
+        store.write(name, {})
+
+    # Should not raise or log warnings
+    _verify_artifacts(store)
+
+
+def test_verify_artifacts_missing(tmp_path, caplog):
+    import logging
+    store = ArtifactStore("eng-001", base_dir=str(tmp_path))
+    store.write("SEMGREP_RAW", {})
+
+    with caplog.at_level(logging.WARNING):
+        _verify_artifacts(store)
+
+    assert "SBOM" in caplog.text
+    assert "INFRA_MAP" in caplog.text
+
+
+# ─── _fallback_output ────────────────────────────────────────────────────────
+
+
+def test_fallback_output_has_all_keys():
+    output = _fallback_output("connection refused")
+
+    assert output["semgrep_error"] == "connection refused"
+    assert output["sca_error"] == "connection refused"
+    assert output["joern_success"] is False
+    assert output["semgrep_findings_count"] == 0
+    assert output["sca_vulns_count"] == 0
+    assert output["infra_open_ports"] == 0
+    assert "failed" in output["summary"]
+
+
+# ─── run_pre_recon (agent mocked) ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_pre_recon_success(tmp_path):
+    from src.agents.pre_recon import run_pre_recon
+
+    config = _make_config(joern_enabled=False)
+    store = ArtifactStore(config.meta.engagement_id, base_dir=str(tmp_path))
+    store.write("PREFLIGHT_RESULT", {
+        "status": "pass",
+        "repo_profile": {
+            "languages": ["javascript"],
+            "semgrep_rulesets": ["p/owasp-top-ten", "p/javascript"],
+            "joern_enabled": False,
+        },
+    })
+
+    # Simulate that agent wrote artifacts via Bash
+    for name in ["SEMGREP_RAW", "SBOM", "INFRA_MAP", "TECH_STACK", "JOERN_CPG_PATH"]:
+        store.write(name, {})
+
+    mock_output = {
+        "semgrep_findings_count": 2,
+        "semgrep_error": None,
+        "sca_vulns_count": 1,
+        "sca_lockfile_found": True,
+        "sca_error": None,
+        "infra_open_ports": 3,
+        "joern_success": False,
+        "joern_error": "Joern disabled in config",
+        "summary": "Scanned successfully",
+    }
+
+    with patch(
+        "src.agents.pre_recon.run_agent",
+        new_callable=AsyncMock,
+        return_value={"result": "", "structured_output": mock_output, "error": None},
+    ):
+        result = await run_pre_recon(config, store)
+
+    assert result["semgrep_findings_count"] == 2
+    assert result["sca_lockfile_found"] is True
+    assert result["summary"] == "Scanned successfully"
+
+
+@pytest.mark.asyncio
+async def test_run_pre_recon_agent_failure(tmp_path):
+    from src.agents.pre_recon import run_pre_recon
+
+    config = _make_config()
+    store = ArtifactStore(config.meta.engagement_id, base_dir=str(tmp_path))
+
+    with patch(
+        "src.agents.pre_recon.run_agent",
+        new_callable=AsyncMock,
+        return_value={"result": "", "structured_output": None, "error": "API timeout"},
+    ):
+        result = await run_pre_recon(config, store)
+
+    # Should use fallback output
+    assert result["semgrep_error"] == "API timeout"
+    assert result["joern_success"] is False
+    assert "failed" in result["summary"]


### PR DESCRIPTION
## Summary

- **Pre-recon agent** moved from `src/services/` to `src/agents/pre_recon.py` — single LLM agent runs all Phase 1 scans (Semgrep, Trivy, nmap, subfinder, pd-httpx, Joern)
- **Artifact store** (`src/artifacts/store.py`) — typed JSON inter-phase communication. Agent writes SEMGREP_RAW, SBOM, INFRA_MAP, TECH_STACK, JOERN_CPG_PATH directly via Bash (fixes structured output errors with non-Claude models)
- **Guided autonomy prompts** — hard rules on artifact format + scope enforcement, soft guidelines on scan strategy. Agent adapts flags, retries with broader rulesets, probes additional paths based on target
- **Scope rules + preflight context** injected into agent prompt — frameworks, languages, excluded paths all visible to the agent
- **Dockerfile**: renamed PD httpx → `pd-httpx` (fixes Python httpx CLI collision), added Node.js for lockfile generation, added non-root user
- **Cleanup**: deleted unused service files (sast_scanner, sca_scanner, infra_scanner, joern_builder) superseded by agent approach

## Tickets
- INT-284: Artifact store for inter-phase communication
- INT-285: Semgrep SAST scanner
- INT-286: Trivy SCA scanner
- INT-287: Infrastructure scanning (nmap, subfinder, httpx)

## Test plan
- [x] `uv run pytest tests/test_pre_recon.py` — 13 tests passing
- [x] `uv run pytest tests/test_artifact_store.py` — 7 tests passing
- [x] `uv run pytest tests/` — 80 tests passing, 0 failures
- [ ] Manual: `docker compose build && ./adversa dev CONFIG=configs/juiceshop.config.yaml`
- [ ] Verify all 5 artifact files written to `runs/{id}/artifacts/`
- [ ] Verify SBOM has vulnerabilities (lockfile generated via npm)
- [ ] Verify pd-httpx tech detection works (no Python httpx collision)

